### PR TITLE
Adds working title scanner

### DIFF
--- a/add_movies_to_collection.py
+++ b/add_movies_to_collection.py
@@ -1,0 +1,10 @@
+
+# This script will open a csv file (passed in on cli) that has movie titles and years and then
+# add each movie to a collection that matches the name of the file.
+
+import sys
+from mutagen.mp4 import MP4, MP4Tags
+
+print('Adding movies to a collection')
+video = MP4('/media/nas/Movies/2010-2019/99 Homes (2014).mp4')
+print(video.tags)

--- a/find_title_file_mismatches.py
+++ b/find_title_file_mismatches.py
@@ -1,21 +1,127 @@
+#!bin/python3
 import os
-from plex_utils import fetch_movies_from_library, filename_to_movie
 
-# go through all movies and see if the plex title matches the file
+from plex_utils import *
+from tmdb_utils import fetch_movie_from_tmdb
+from time import sleep
+from mutagen.mp4 import MP4, MP4Tags
+import datetime
+
+PLEX_LIBRARY_NAME = 'Movies'
+
+# takes name or full path of file and tries to split it
+# example: 'Some Cool Movie (2010)' -> {'title': 'Some Cool Movie', 'year':2010}
+def _filename_to_movie(filepath: str):
+    filename = os.path.basename(filepath)
+    title_year = re.compile(r"(.*) \((\d{4})\)")
+    if title_year.match(filename):  
+        groups = title_year.match(filename).groups()
+        return {'title':  groups[0], 'year': int(groups[1]), 'filename': filepath}
+    else:
+        return {}
+
+def _fetch_mp4_title_year(file_path):
+    video = MP4(file_path)
+
+    tags = video.tags or {}
+    title = tags.get('\xa9nam', '')
+    while isinstance(title, list):
+        title = title[0]    
+    year = tags.get('\xa9day', '1500')
+    while isinstance(year, list):
+        year = year[0]       
+    return (str(title), str(year))
+
+
+def _update_mp4_title_year(file_path, new_title, new_year):
+    # Load the MP4 file
+    video = MP4(file_path)
+
+    # Access tags
+    tags = video.tags
+    if tags is None:
+        video.add_tags()
+        tags = video.tags
+
+    # Update metadata
+    tags['\xa9nam'] = str(new_title)  # Title tag
+    tags['\xa9day'] = str(new_year)   # Year tag
+
+    # Save changes
+    ts = str(datetime.datetime.now())
+    video.save()
+    print(f"{ts} Updated file '{file_path}' metadata with title '{new_title}' and year '{new_year}.'")
+
 if __name__ == "__main__":
-
-    movies = fetch_movies_from_library('Movies')
-    for movie in movies:
-        if not movie or not movie['filename']:
-            print('No filename ' + movie)
-            continue
-        check = filename_to_movie(movie['filename'])
-        if len(check) == 0:
-            print(f"Filename malformed: {movie['filename']}")
-            continue
-
-        if check['title'].lower() != movie['title'].lower() or check['year'] != movie['year']:
-            print("Title or year in plex doesn't match filename")
-            print(f"P Title: {movie['title']}\nF Title: {check['title']}")
-            print(f"P Year: {movie['year']}\nF Year: {check['year']}\n\n")
     
+    SLICE_START = 500
+    SLICE_END = SLICE_START + 200
+
+    print(f"Running movie title scanner with slice start {SLICE_START} and slice end {SLICE_END}")
+    print('Fetching the movies from the plex server, this could take some time.')
+    movies = fetch_movie_infos_from_library(PLEX_LIBRARY_NAME)
+    tags_to_do = []
+    plex_titles_to_do = []
+
+    for movie in movies[SLICE_START:SLICE_END]:
+        sleep(.1)
+        tmdb_entry = fetch_movie_from_tmdb(movie['title'], movie['year'])
+        if tmdb_entry:
+            # If the movie fetch gets something, we just mark it for tag update
+
+            if movie['title'] == tmdb_entry['title'] and movie['year'] == int(tmdb_entry['release_date'][:4]):
+                print(f"[MATCH] -- {movie['title']} ({movie['year']})")            
+            else:
+                print(f"\n[PLEX] -- {movie['title']} ({movie['year']})")
+                print(f"[TMDB] -- {tmdb_entry['title']} ({tmdb_entry['release_date'][:4]})\n")
+            
+            tags_to_do.append({
+                'title': tmdb_entry['title'],
+                'year': tmdb_entry['release_date'][:4],
+                'file_path': movie['filename']
+            })
+
+        else:
+            print(f"\n[FAIL] -- {movie['title']} ({movie['year']}) not matched in TMDB")
+            movie_info = _filename_to_movie(movie['filename'])
+            if movie_info:
+                tmdb_entry = fetch_movie_from_tmdb(movie_info['title'], movie_info['year'])
+                if tmdb_entry:
+                    print("[FILE] -- Filename matched a movie in TMDB.")
+
+                    tags_to_do.append({
+                        'title': tmdb_entry['title'],
+                        'year': tmdb_entry['release_date'][:4],
+                        'file_path': movie_info['filename']
+                    })
+                    plex_titles_to_do.append({
+                        # 'title': tmdb_entry['title'],
+                        # 'year': tmdb_entry['release_date'][:4],
+                        'plex_title': movie['title'],
+                        'plex_year': movie['year']
+                    })
+                else:
+                    print("!!!"*10)
+                    print(f"[FAIL] -- Filename '{movie['filename']}' not matched in TMDB either.\n")
+                    # TODO: output the list of misfits somewhere so they can be handled special case
+    
+    # fix all tags that don't already match a TMDB entry
+    for ttd in tags_to_do:
+        tag_title, tag_year = _fetch_mp4_title_year(ttd['file_path'])
+        if tag_title != ttd['title'] or tag_year != ttd['year']:
+            print(f"Tags aren't matched on {ttd['file_path']}, setting them...")
+            _update_mp4_title_year(ttd['file_path'],  ttd['title'], ttd['year'])
+
+    # if the plex movie name or year isn't matching, since we've updated the mp4 tags we can refresh
+    # metadata and it will likely fix it.
+    lib = fetch_plex_library(PLEX_LIBRARY_NAME, 'movie')
+    if not lib:
+        print("Through some kind of magic, no plex library was found.")
+    else:
+        for pttd in plex_titles_to_do:
+            movie = fetch_plex_movie(pttd['plex_title'], pttd['plex_year'], lib)
+            if movie:
+                movie.refresh()
+                print(f"Refreshing the metadata for {pttd['plex_title']} ({pttd['plex_year']}).")
+            else:
+                print(f"Unable to find {pttd['plex_title']} ({pttd['plex_year']}) in plex.")

--- a/plex_utils.py
+++ b/plex_utils.py
@@ -7,39 +7,35 @@ from tokens import get_token
 # Replace these with your Plex server details
 PLEX_URL = 'http://127.0.0.1:32400'
 PLEX_TOKEN = get_token('plextoken')
-
-# takes name or full path of file and tries to split it
-# example: 'Some Cool Movie (2010)' -> {'title': 'Some Cool Movie', 'year':2010}
-def filename_to_movie(filepath: str):
-    filename = os.path.basename(filepath)
-    title_year = re.compile(r"(.*) \((\d{4})\)")
-    if title_year.match(filename):  
-        groups = title_year.match(filename).groups()
-        return {'title':  groups[0], 'year': int(groups[1]), 'filename': filepath}
-    else:
-        return {}
         
 # You can pass in a string to match library types, pass None if no filter applied
-def fetch_libraries(type_filter:str):
+def _fetch_libraries(type_filter:str):
     plex = PlexServer(PLEX_URL, PLEX_TOKEN)
     if type_filter == None:
         return [l for l in plex.library.sections()]
     else:
         return [l for l in plex.library.sections() if l.type == type_filter]
 
-# Returns a list of movies in the library
-def fetch_movies_from_library(lib_to_fetch: str):
+def fetch_plex_library(library_name: str, library_type:str=None):
+    libs = _fetch_libraries(library_type)
+    for l in libs:
+        if l.title == library_name:
+            return l
+    return None    
 
-    plex = PlexServer(PLEX_URL, PLEX_TOKEN)
+def fetch_plex_movie(title: str, year: int, library):
+    results = library.search(title=str(title), year=int(year))
+    if results:
+        return results[0]
+    else:
+        return None
 
-    # Access the Movies library
-    movies_libraries = fetch_libraries('movie')
+# Returns a list of movies in the library. async call scales with size of library
+def fetch_movie_infos_from_library(lib_to_fetch: str):
+
     movies = []
-    
-    for library in movies_libraries:
-        if library.title != lib_to_fetch:
-            continue
-
+    library = fetch_plex_library(lib_to_fetch, 'movie')
+    if library:    
         # Library.all() is blocking and can take seconds to complete
         for movie in library.all():
             movies.append({
@@ -51,13 +47,48 @@ def fetch_movies_from_library(lib_to_fetch: str):
 
 # Looks for the movie in all movie libraries and rates it. wants a 0-10 scale rating
 def rate_movie_in_library(title:str, year:int, rating:float):
-    movie_libraries = fetch_libraries('movie')
+    movie_libraries = _fetch_libraries('movie')
     for lib in movie_libraries:
-        results = lib.search(title=title, year=year)
-        if results:
-            movie = results[0]
+        movie = fetch_plex_movie(title, year, lib)
+        if movie:
             movie.rate(rating)
             return True
+
+    return False
+
+def update_movie_title_year_in_library(plex_title: str, plex_year: int, new_title: str = '', new_year: int = 0) -> bool:
+    movie_libraries = _fetch_libraries('movie')
+    for lib in movie_libraries:
+        movie = fetch_plex_movie(plex_title, plex_year, lib) 
+        if movie:
+            if new_title != '':
+                movie.edit(title=new_title)
+            if new_year != 0:
+                movie.edit(year=new_year)
+            if new_title != '' or new_year != 0:
+                movie.reload()  # Refresh the movie object to reflect changes
+            return True
+        else:
+            return False
+
+def _is_collection_in_library(library_name:str, collection_name: str):
+    libraries = _fetch_libraries('movie')
+    for lib in libraries:
+         if library.title == library_name:
+            matching_collections = [c for c in lib.collections() if c.title == collection_name]
+            return len(matching_collections) > 0
+    return False
+
+
+def add_movie_to_collection(plex_movie_title: str, collection_name: str):
+    libraries = [l for l in _fetch_libraries('movie') if is_collection_in_library(l.title, collection_name)]
+    if libraries:
+        l = libraries[0]
+        movie = l.get(plex_movie_title)
+        if collection_name not in [col.tag for col in movie.collections]:
+            movie.addCollection(collection_name)
+            
+        return True
 
     return False
 

--- a/test/plex_utils_test.py
+++ b/test/plex_utils_test.py
@@ -1,0 +1,9 @@
+import unittest
+import sys
+sys.path.appened('..')
+from plex_utils import update_movie_title_year_in_library
+
+class TestPlexUtils(unittest.TestCase):
+
+    def test_update_movie_title_year(self):
+        pass

--- a/tmdb_utils.py
+++ b/tmdb_utils.py
@@ -1,0 +1,37 @@
+from tokens import get_token
+from urllib.parse import quote
+import requests
+import json
+
+TMDB_TOKEN=get_token('tmdbtoken')
+
+
+def fetch_movie_from_tmdb(title: str, year: int):
+    """
+    Tries to find a movie with the title provided in tmdb and yerifies the year is within 2 years of what is passed in.
+    """
+    escaped_title = quote(title)
+    url = f"https://api.themoviedb.org/3/search/movie?query={escaped_title}&include_adult=true&language=en-US&page=1"
+
+    headers = {
+        "accept": "application/json",
+        "Authorization": f"Bearer {TMDB_TOKEN}"
+    }
+
+    response = requests.get(url, headers=headers)
+    if not response.ok:
+        return {'error_code': response.status_code}
+
+    # There should be a field named 'results' that holds the matching movies
+    d = json.loads(response.text)
+    results = d['results']
+    for movie in results:
+        # Sometimes there isn't a release date in the results, we should skip if so.
+        try:
+            m_year = int(movie.get('release_date', '1000')[:4])
+        except:
+            continue
+        if abs(year - m_year) < 3:
+            return movie
+    
+    return {}


### PR DESCRIPTION
Fleshes out the plex utils a bit, just convenience stuff to make the calls easier on scripts.

Sets up a scanner that looks through the plex library and sees if there are significant mismatches, that is TMDB returns nothing when we try the title. If that happens, we look at the file name to see if we can get something better from tmdb and if we still can't it gives up on that movie and moves on.

After the slice of movies is checked with tmdb the script updates the mp4 tags to have a good title and year from TMDB.

After that is done, we refresh all plex movies that missed and we had to refer to the file so the local metadata is picked up and used instead.